### PR TITLE
mod: update docker compose command to latest version

### DIFF
--- a/docs/issuer/reverse-hash-service.md
+++ b/docs/issuer/reverse-hash-service.md
@@ -32,33 +32,27 @@ Docker set up should only be used for testing purposes only
 ### Requirements
 
 - Unix-based operating system (e.g. Debian, Arch, Mac OS X)
-- [Docker Engine](https://docs.docker.com/engine/) 1.27
+- [Docker Engine](https://docs.docker.com/engine/) 1.48
 
 1. Start the services
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 2. Copy schema.sql to the db container
 
 ```bash
-docker cp schema.sql reverse-hash-service_db_1:/
+docker cp schema.sql reverse-hash-service-db-1:/
 ```
 
 3. Exec db container
 
 ```bash
-docker exec -it reverse-hash-service_db_1 /bin/bash
+docker exec -it reverse-hash-service-db-1 /bin/bash
 ```
 
-4. Create RHS DB
-
-```bash
-createdb -U iden3 -h localhost rhs
-```
-
-5. Upload schema.sql inside on docker container
+4. Upload schema.sql inside on docker container
 
 ```bash
 psql -h localhost -U iden3  -d rhs < schema.sql


### PR DESCRIPTION
Hello Team

In today's docker engine: `1.48`, `compose` sub-command is already available. So we do not need to install `docker-compose` binary differently.

In this commit, I have done:
- Modified `reverse-hash-service.md` to use `docker compose` command instead of `docker-compose`.
- Replace `reverse-hash-service_db_1` with the actual db name i.e `reverse-hash-service-db-1`.
- Remove `# Create RHS DB` section because `rhs` database is initially created from `docker-compose.yml` file.

> Note: I have tested this in Ubuntu System using docker engine version `1.48`.